### PR TITLE
LMS: CMake: Linux: migrate udev rules to /usr

### DIFF
--- a/UNS/CMakeLists.txt
+++ b/UNS/CMakeLists.txt
@@ -139,7 +139,7 @@ if (UNIX)
   install (FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/linux_scripts/70-persistent-mei.rules
     ${CMAKE_CURRENT_SOURCE_DIR}/linux_scripts/70-mei-wdt.rules
-    DESTINATION /lib/udev/rules.d/
+    DESTINATION /usr/lib/udev/rules.d/
   )
 
   install (FILES ${CMAKE_CURRENT_SOURCE_DIR}/linux_scripts/20-lms.conf


### PR DESCRIPTION
With the upcoming v254 release of systemd mandating usrmerge[1] this will become mandatory for anyone using systemd.

[1] https://lists.freedesktop.org/archives/systemd-devel/2023-June/049173.html