### PR TITLE
LMS : fix build issue with gcc 15

### DIFF
--- a/MEIClient/Include/MEICommand.h
+++ b/MEIClient/Include/MEICommand.h
@@ -12,6 +12,7 @@
 #define __MEI_COMMAND_H__
 #include "heci.h"
 #include "MEIClientException.h"
+#include <cstdint>
 #include <memory>
 #include <vector>
 


### PR DESCRIPTION
include cstdint header to resolve the below error with gcc 15

| In file included from /lms/2406.0.0.0/git/MEIClient/src/MEICommand.cpp:11: | /lms/2406.0.0.0/git/MEIClient/Include/MEICommand.h:40:54: error: 'uint8_t' was not declared in this scope